### PR TITLE
Deck-themes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ langchain_community == 0.0.28
 lancedb == 0.6.3
 langchain-openai == 0.0.8
 chroma == 0.2.0
+lark == 1.1.9
 langchain-chroma == 0.1.0
 gradio == 4.26.0
 streamlit == 1.33.0

--- a/src/streamlit/app.py
+++ b/src/streamlit/app.py
@@ -48,18 +48,21 @@ def get_commander_data(commander: str) -> pd.DataFrame:
     )
 
 
-def generate_deck_theme_suggestions(commander_data: pd.DataFrame) -> str:
-    """Generate deck theme suggestions based on the commander's abilities and general strategy of the deck."""
+@st.cache_data
+def generate_deck_theme_suggestion(commander_data: pd.DataFrame) -> str:
+    """Generate deck theme suggestion based on the commander's abilities and general strategy of the deck."""
     deck_theme_prompt = PromptTemplate.from_template(
         """"
-        Suggest a theme for a commander deck with {commander} as the commander. 
-        Your suggestion should be based on the commander's abilities and the general strategy of the deck.
+        Suggest a theme for a commander deck with {commander} as the commander.
 
         Do not suggest the commander card itself.
 
         Do not include any extra information in the response.
+
+        Keep your theme description short and focussed on the commander's abilities.
         """
     )
+    ic(deck_theme_prompt)
 
     theme_chain = deck_theme_prompt | LLM
 
@@ -70,29 +73,39 @@ def generate_deck_theme_suggestions(commander_data: pd.DataFrame) -> str:
     return theme_result
 
 
-creature_prompt = PromptTemplate.from_template(
-    """"
-    Design a single Magic the Gathering creature type card that would be valuable to include in a commander deck with {commander} as the commander. 
-    Do not suggest the commander card itself.
-    Your suggestions should be based on the commander's abilities and the general strategy of the deck.
+@st.cache_data
+def generate_another_theme_suggestion(
+    commander_data: pd.DataFrame, previous_theme
+) -> str:
+    """Generate another deck theme suggestion based on the commander's abilities and general strategy of the deck."""
+    deck_theme_prompt = PromptTemplate.from_template(
+        """"
+        Suggest a theme for a commander deck with {commander} as the commander.
 
-    Your response should be a card formated in json, each with the following information:
-    - Name
-    - Mana cost
-    - Supertypes
-    - Types
-    - Subtypes
-    - Text
-    - Power
-    - Toughness
+        Do not suggest the commander card itself.
 
-    Do not suggest to include the commander itself.
+        Do not include any extra information in the response.
 
-    Do not include any extra information in the response.
+        Keep your theme description short and focussed on the commander's abilities.
 
-    Only use the commanders colour identity for the card.
-    """
-)
+        Make a suggestion that is different from the previous theme.
+
+        The previous theme was: {previous_theme}
+        """
+    )
+
+    # TODO: Make the theme suggestion even more different from the previous theme
+
+    theme_chain = deck_theme_prompt | LLM
+
+    commander_description = commander_data.to_dict(orient="records")
+
+    theme_result = theme_chain.invoke(
+        {"commander": commander_description, "previous_theme": previous_theme}
+    )
+
+    return theme_result
+
 
 mtg_prompt_template = PromptTemplate.from_template(
     """"
@@ -134,21 +147,15 @@ partial_prompts = {
 def generate_card_suggestions(
     prompt: BasePromptTemplate, commander_data: pl.DataFrame, commander: str, theme: str
 ) -> pd.DataFrame:
-    # use ic for each argument
-    for arg in [prompt, commander_data, commander, theme]:
-        ic(arg)
-
     prompt = prompt.partial(commander=commander)
-    ic(prompt)
 
     hyde_embeddings = HypotheticalDocumentEmbedder.from_llm(
         llm=LLM, base_embeddings=EMBEDDINGS, custom_prompt=prompt
     )
-    ic(hyde_embeddings)
 
     hyde_result = hyde_embeddings.embed_query(
         theme
-    )  # BUG: hyde_embeddings.embed_query({"commander": commander, "theme": theme}) complains about key error, again. I got around this last time but having a prompt with 1 arg left
+    )  # TODO: report possible bug that hyde_embeddings.embed_query({"commander": commander, "theme": theme}) complains about key error, again. I got around this last time but having a prompt with 1 arg left
 
     hyde_search = VECTORSTORE.similarity_search_by_vector_with_relevance_scores(
         hyde_result, k=20
@@ -157,7 +164,6 @@ def generate_card_suggestions(
     suggestions = [document[0].metadata for document in hyde_search]
 
     # log if commander card name in metadata
-    # TODO: restructure the data prep into a separate function
     for item in suggestions:
         if commander in item["name"]:
             LOG.info("Commander card in metadata", metadata=item)
@@ -201,77 +207,67 @@ def generate_card_suggestions(
     return display_suggestions.to_pandas()
 
 
-st.session_state.commander_name: str = st.selectbox("Commander", COMMANDER_NAMES)
+st.session_state.commander_name = str(st.selectbox("Commander", COMMANDER_NAMES))
 
 st.session_state.commander_data = get_commander_data(
-    commander=st.session_state.commander_name
+    commander=str(st.session_state.commander_name)
 )
 
 st.write(st.session_state.commander_data)
 
-if st.button("Generate deck theme suggestions"):
-    st.session_state.deck_theme_suggestion_1 = generate_deck_theme_suggestions(
+st.session_state.selected_theme = None
+
+if "themes_generated" not in st.session_state:
+    st.session_state.themes_generated = False
+    st.session_state.themes = {"a": None, "b": None}
+
+
+def click_theme_button():
+    st.session_state.themes_generated = True
+
+
+st.button("Generate deck theme suggestions", on_click=click_theme_button)
+
+if st.session_state.themes_generated:
+    st.session_state.themes = generate_deck_theme_suggestion(
         st.session_state.commander_data
     )
-    st.write(st.session_state.deck_theme_suggestion_1)
 
-    st.session_state.deck_theme_suggestion_2 = generate_deck_theme_suggestions(
-        st.session_state.commander_data
-    )
-    st.write(st.session_state.deck_theme_suggestion_2)
-
-if st.button("Use deck theme suggestion 1"):
-    st.session_state.deck_theme = st.session_state.deck_theme_suggestion_1
-
-    st.write("## Choosen theme", st.session_state.deck_theme)
-
-    st.session_state.suggestions = {
-        card_type: generate_card_suggestions(
-            prompt=prompt,
-            commander_data=st.session_state.commander_data,
-            commander=st.session_state.commander_name,
-            theme=st.session_state.deck_theme,
-        )
-        for card_type, prompt in partial_prompts.items()
+    st.session_state.themes = {
+        "a": generate_deck_theme_suggestion(st.session_state.commander_data),
+        "b": generate_another_theme_suggestion(
+            st.session_state.commander_data, st.session_state.themes
+        ),
     }
 
-    st.write(
-        "## Creatures",
-        st.session_state.suggestions.get("creatures"),
-        "## Enchantments",
-        st.session_state.suggestions.get("enchantments"),
-        "## Artifacts",
-        st.session_state.suggestions.get("artifacts"),
-        "## Instants",
-        st.session_state.suggestions.get("instants"),
-        "## Sorceries",
-        st.session_state.suggestions.get("sorceries"),
+    st.session_state.selected_theme = st.radio(
+        "Choose a deck theme suggestion",
+        options=[st.session_state.themes["a"], st.session_state.themes["b"]],
     )
 
-elif st.button("Use deck theme suggestion 2"):
-    st.session_state.deck_theme = st.session_state.deck_theme_suggestion_2
+    if st.button("Generate card suggestions"):
+        st.session_state.suggestions = {
+            card_type: generate_card_suggestions(
+                prompt=prompt,
+                commander_data=st.session_state.commander_data,
+                commander=st.session_state.commander_name,
+                theme=st.session_state.selected_theme,
+            )
+            for card_type, prompt in partial_prompts.items()
+        }
 
-    st.write("## Choosen theme", st.session_state.deck_theme)
+        # TODO: Instead of displaying each suggestion data set based on the expected input card type, aggregate them, then split into the actual types
+        # TODO: Instead of displaying the vectors based on similarity, have them filtered/ reranked by an llm
 
-    st.session_state.suggestions = {
-        card_type: generate_card_suggestions(
-            prompt=prompt,
-            commander_data=st.session_state.commander_data,
-            commander=st.session_state.commander_name,
-            theme=st.session_state.deck_theme,
+        st.write(
+            "## Creatures",
+            st.session_state.suggestions.get("creatures"),
+            "## Enchantments",
+            st.session_state.suggestions.get("enchantments"),
+            "## Artifacts",
+            st.session_state.suggestions.get("artifacts"),
+            "## Instants",
+            st.session_state.suggestions.get("instants"),
+            "## Sorceries",
+            st.session_state.suggestions.get("sorceries"),
         )
-        for card_type, prompt in partial_prompts.items()
-    }
-
-    st.write(
-        "## Creatures",
-        st.session_state.suggestions.get("creatures"),
-        "## Enchantments",
-        st.session_state.suggestions.get("enchantments"),
-        "## Artifacts",
-        st.session_state.suggestions.get("artifacts"),
-        "## Instants",
-        st.session_state.suggestions.get("instants"),
-        "## Sorceries",
-        st.session_state.suggestions.get("sorceries"),
-    )

--- a/src/streamlit/app.py
+++ b/src/streamlit/app.py
@@ -52,6 +52,28 @@ def get_commander_data(commander) -> pd.DataFrame:
     )
 
 
+def generate_deck_theme_suggestions(commander_data: pd.DataFrame) -> str:
+    """Generate deck theme suggestions based on the commander's abilities and general strategy of the deck."""
+    deck_theme_prompt = PromptTemplate.from_template(
+        """"
+        Suggest a theme for a commander deck with {commander} as the commander. 
+        Your suggestion should be based on the commander's abilities and the general strategy of the deck.
+
+        Do not suggest the commander card itself.
+
+        Do not include any extra information in the response.
+        """
+    )
+
+    theme_chain = deck_theme_prompt | llm
+
+    commander_description = commander_data.to_dict(orient="records")
+
+    theme_result = theme_chain.invoke({"commander": commander_description})
+
+    return theme_result
+
+
 creature_prompt = PromptTemplate.from_template(
     """"
     Design a single Magic the Gathering creature type card that would be valuable to include in a commander deck with {commander} as the commander. 


### PR DESCRIPTION
- Utilise deck theme suggestions before retrieval allowing the user to select between 2
- Extend types of card to include sagas, lands and planeswalkers
- Display all suggestions in one panel after filtering for duplicates and colours
- Utilise Pydantic for structured data return from LLMs
